### PR TITLE
doc: Fix typos

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+*.md @codacy/techwriters
+*.html @codacy/techwriters

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Codacy IntelliJ IDEA Extension
+# Codacy IntelliJ Plugin
 
-The Codacy extension for IntelliJ IDEs helps you review and manage the issues found by Codacy directly within IntelliJ IDEs. It notifies you whether a pull request is up to standards by highlighting problematic code patterns and displaying code quality metrics.
+The Codacy plugin for IntelliJ helps you review and manage the issues found by Codacy directly within IntelliJ IDEs. It notifies you whether a pull request is up to standards by highlighting problematic code patterns and displaying code quality metrics.
 
-![Codacy IntelliJ IDEA Extension Screenshot](https://github.com/codacy/codacy-intellij-extension/raw/HEAD/.readme/screenshot-01.png)
+![Codacy IntelliJ Plugin Screenshot](https://github.com/codacy/codacy-intellij-extension/raw/HEAD/.readme/screenshot-01.png)
 
 [Codacy](https://www.codacy.com/) is an automated code review tool that helps your team write high-quality code by analyzing over 40 programming languages, such as PHP, JavaScript, Python, Java, and Ruby. Codacy lets you define and enforce your own quality rules, code patterns, and quality settings to prevent issues in your codebase.
 
@@ -10,7 +10,7 @@ The Codacy extension for IntelliJ IDEs helps you review and manage the issues fo
 
 ## Prerequisites
 
-Before installing the extension, make sure you meet the following requirements:
+Before installing the plugin, make sure you meet the following requirements:
 
 1.  You have a [Codacy account](https://www.codacy.com/signup-codacy).
 2.  The repository you’re working on has been [added to Codacy Cloud](https://docs.codacy.com/organizations/managing-repositories/#adding-a-repository).
@@ -20,21 +20,21 @@ Before installing the extension, make sure you meet the following requirements:
 
 ### From JetBrains Marketplace
 
-1.  Open IntelliJ IDEA and navigate to `Settings` > `Plugins`.
+1.  Open your IntelliJ IDE and navigate to `Settings` > `Plugins`.
 2.  Search for "Codacy" in the Marketplace tab.
-3.  Click `Install` and restart IntelliJ IDEA.
+3.  Click `Install` and restart your IntelliJ IDE.
 
 ### Manually Installing
 
 1.  Download the latest `.zip` file from the [releases page](https://github.com/codacy/codacy-intellij-extension/releases).
-2.  Open IntelliJ IDEA and navigate to `Settings` > `Plugins`.
+2.  Open your IntelliJ IDE and navigate to `Settings` > `Plugins`.
 3.  Click the gear icon and choose `Install Plugin from Disk...`.
-4.  Select the downloaded `.zip` file and restart IntelliJ IDEA.
+4.  Select the downloaded `.zip` file and restart your IntelliJ IDE.
 
 ### Building from Source
 
 1.  Clone the repository from GitHub.
-2.  Open the project in IntelliJ IDEA.
+2.  Open the project in your IntelliJ IDE.
 3.  Run ./gradlew buildPlugin
 4.  The built plugin will be located in the `build/distributions` directory.
 5.  Install the plugin manually
@@ -51,7 +51,7 @@ For information on how to contribute to this project, please refer to the [contr
 
 ## Troubleshooting
 
-If you're having trouble using the Codacy extension for VS Code, see below to troubleshoot errors.
+If you're having trouble using the Codacy plugin, see below to troubleshoot errors.
 
 ### <span class="skip-vale">Could not</span> find repository
 
@@ -59,6 +59,6 @@ If you see this error, confirm that the repository has been [added to Codacy Clo
 
 <!-- Plugin description -->
 
-The Codacy extension for IntelliJ IDEA helps you review and manage the issues found by Codacy directly within IntelliJ IDEA. It notifies you whether a pull request is up to standards by highlighting problematic code patterns and displaying code quality metrics.
+The Codacy plugin for IntelliJ helps you review and manage the issues found by Codacy directly within your IntelliJ IDE. It notifies you whether a pull request is up to standards by highlighting problematic code patterns and displaying code quality metrics.
 
 <!-- Plugin description end -->


### PR DESCRIPTION
* Updates naming: `extension` -> `plugin`.
* Removes hardcoded references to IDEA since the plugin supports multiple IDEs.
* Fixes some typos.
* Adds CODEOWNERS