### PR TITLE
feat: Fixed widget icon CF-1798

### DIFF
--- a/src/main/kotlin/com/codacy/intellij/plugin/listeners/StartupListener.kt
+++ b/src/main/kotlin/com/codacy/intellij/plugin/listeners/StartupListener.kt
@@ -1,9 +1,12 @@
 package com.codacy.intellij.plugin.listeners
 
 import com.codacy.intellij.plugin.services.api.Api
+import com.codacy.intellij.plugin.services.cli.CodacyCli
+import com.codacy.intellij.plugin.services.common.GitRemoteParser
 import com.codacy.intellij.plugin.services.common.IconUtils
 import com.codacy.intellij.plugin.services.git.GitProvider
 import com.codacy.intellij.plugin.services.git.RepositoryManager
+import com.codacy.intellij.plugin.views.CodacyCliStatusBarWidgetFactory
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.StartupActivity
@@ -11,6 +14,7 @@ import git4idea.repo.GitRepository
 import git4idea.repo.GitRepositoryChangeListener
 import kotlinx.coroutines.*
 
+//Note: This Class runs AFTER WidgetFactory
 class StartupListener : StartupActivity {
 
     @OptIn(DelicateCoroutinesApi::class)
@@ -22,6 +26,16 @@ class StartupListener : StartupActivity {
         val repositoryManager = project.service<RepositoryManager>()
         if (gitRepository != null && repositoryManager.currentRepository != gitRepository)
             GlobalScope.launch { repositoryManager.open(gitRepository) }
+
+        val remote = gitRepository?.remotes?.firstOrNull()
+            ?: throw IllegalStateException("No remote found in the Git repository")
+
+        val gitInfo = GitRemoteParser.parseGitRemote(remote.firstUrl!!)
+
+        CodacyCli.getService(
+            gitInfo.provider, gitInfo.organization, gitInfo.repository, project,
+            CodacyCliStatusBarWidgetFactory.widget!!
+        )
 
         GlobalScope.launch {
             Api().listTools()

--- a/src/main/kotlin/com/codacy/intellij/plugin/services/cli/behaviour/UnixBehaviour.kt
+++ b/src/main/kotlin/com/codacy/intellij/plugin/services/cli/behaviour/UnixBehaviour.kt
@@ -5,7 +5,7 @@ import com.codacy.intellij.plugin.services.common.Config
 import com.intellij.openapi.project.Project
 import java.nio.file.Path
 
-class LinuxBehaviour : CodacyCliBehaviour {
+class UnixBehaviour : CodacyCliBehaviour {
 
     override fun rootPath(project: Project): String {
         return project.basePath ?: throw IllegalStateException("Project base path is not set")

--- a/src/main/kotlin/com/codacy/intellij/plugin/views/CodacyCliStatusBarWidget.kt
+++ b/src/main/kotlin/com/codacy/intellij/plugin/views/CodacyCliStatusBarWidget.kt
@@ -4,7 +4,6 @@ import com.codacy.intellij.plugin.services.cli.CodacyCli
 import com.codacy.intellij.plugin.services.common.IconUtils
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.startup.StartupManager
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.wm.StatusBar
 import com.intellij.openapi.wm.StatusBarWidget
@@ -49,7 +48,7 @@ class CodacyCliStatusBarWidget(private val project: Project) : StatusBarWidget, 
 
         data object NOT_INSTALLED : State {
             override fun toString() = "Not Installed"
-            override val icon: Icon = AllIcons.General.Information
+            override val icon: Icon = AllIcons.General.Gear
         }
     }
 
@@ -60,11 +59,7 @@ class CodacyCliStatusBarWidget(private val project: Project) : StatusBarWidget, 
     override fun ID(): String = "com.codacy.intellij.plugin.views.CodacyCliStatusBarWidget"
 
     override fun install(statusBar: StatusBar) {
-        StartupManager.getInstance(project).runWhenProjectIsInitialized {
-            CodacyCli.Companion.getService(project)
-                .registerWidget(this)
-            this.statusBar = statusBar
-        }
+        this.statusBar = statusBar
     }
 
     override fun dispose() {}

--- a/src/main/kotlin/com/codacy/intellij/plugin/views/CodacyCliStatusBarWidgetFactory.kt
+++ b/src/main/kotlin/com/codacy/intellij/plugin/views/CodacyCliStatusBarWidgetFactory.kt
@@ -13,8 +13,19 @@ class CodacyCliStatusBarWidgetFactory: StatusBarWidgetFactory {
 
     override fun isAvailable(project: Project): Boolean = true
 
-    override fun createWidget(project: Project): StatusBarWidget =
-        CodacyCliStatusBarWidget(project)
+    companion object {
+        //TODO: This might be not the best way to handle it,
+        // but CLI Service needs access to the widget,
+        // and the widget will be instantiated before
+        // StartupListener for some reason.
+        var widget: CodacyCliStatusBarWidget? = null
+    }
+
+    override fun createWidget(project: Project): StatusBarWidget {
+        val widget = CodacyCliStatusBarWidget(project)
+        Companion.widget = widget
+        return widget
+    }
 
     override fun disposeWidget(statusBarWidget: StatusBarWidget) {
         Disposer.dispose(statusBarWidget)


### PR DESCRIPTION
- Changed startup logic to make more sense
  - CLI startup moved to StartupListener
  - CLIWidgetFactory assigns widget to its companion object so that it can be accessed by the CLI (I am not happy about this but Intellij was refusing to update the icon despite the underlying logic changing the event triggers)

- Re-introduced CodacyCLI to be a service, not standalone class. It is recommended by Jetbrains and makes it easier to access the service from other classes. It also fixes the issues of the CLI losing the reference to the Widget, breaking its state changes.

- Renamed LinuxBehaviour to UnixBehaviour as it works for both Linux and MacOS