### PR TITLE
Feat/cf 1895 multiple agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ build
 
 # Ignore IntelliJ AI rules
 .junie/guidelines.md
+
+
+# Ignore IntelliJ AI rules
+.github/copilot-instructions.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,4 @@
 
 ### Added
 
-- Added support for local scanning using Codacy's cli v2
-- Support new versions of the IDEA products
+- Added support for Codacy MCP with both Junie and GitHub Copilot on Linux and macOS

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.codacy.intellij.plugin
 pluginName = codacy-intellij-plugin
 pluginRepositoryUrl = https://github.com/codacy/codacy-intellij-extension
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.7
+pluginVersion = 0.0.8
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 223

--- a/src/main/kotlin/com/codacy/intellij/plugin/services/agent/AiAgent.kt
+++ b/src/main/kotlin/com/codacy/intellij/plugin/services/agent/AiAgent.kt
@@ -17,8 +17,22 @@ import java.nio.file.Paths
 import kotlin.io.path.isRegularFile
 import kotlin.io.path.readText
 
+enum class AiAgentName {
+    JUNIE,
+    GITHUB_COPILOT;
+
+    override fun toString(): String {
+        return when (this) {
+            JUNIE -> "Junie Agent"
+            GITHUB_COPILOT -> "GitHub Copilot Agent"
+        }
+    }
+}
+
+
 sealed class AiAgent {
 
+    abstract val aiAgentName: AiAgentName
     abstract val pluginId: String
 
     abstract val mcpConfigurationPath: Path
@@ -95,6 +109,9 @@ sealed class AiAgent {
                 runCatching { Files.size(guidelinesFilePath) }.getOrDefault(0L) > 0L
 
     class JUNIE(override val projectPath: Path, override val homePath: Path) : AiAgent() {
+
+        override val aiAgentName: AiAgentName = AiAgentName.JUNIE
+
         override val pluginId: String = "org.jetbrains.junie"
 
         override val mcpConfigurationPath: Path =
@@ -106,10 +123,13 @@ sealed class AiAgent {
         override val guidelinesFilePath: Path =
             Paths.get(projectPath.toString(), ".junie", "guidelines.md")
 
-        override fun toString() = "Junie Agent"
+        override fun toString() = aiAgentName.toString()
     }
 
     class GITHUB_COPILOT(override val projectPath: Path, override val homePath: Path) : AiAgent() {
+
+        override val aiAgentName: AiAgentName = AiAgentName.GITHUB_COPILOT
+
         override val pluginId: String = "com.github.copilot"
 
         override val mcpConfigurationPath: Path =
@@ -121,6 +141,6 @@ sealed class AiAgent {
         override val guidelinesFilePath: Path =
             Paths.get(projectPath.toString(), ".github", "copilot-instructions.md")
 
-        override fun toString() = "GitHub Copilot Agent"
+        override fun toString() = aiAgentName.toString()
     }
 }

--- a/src/main/kotlin/com/codacy/intellij/plugin/services/common/Config.kt
+++ b/src/main/kotlin/com/codacy/intellij/plugin/services/common/Config.kt
@@ -1,5 +1,6 @@
 package com.codacy.intellij.plugin.services.common
 
+import com.codacy.intellij.plugin.services.agent.AiAgentName
 import com.codacy.intellij.plugin.services.api.Api
 import com.codacy.intellij.plugin.telemetry.Telemetry
 import com.intellij.credentialStore.CredentialAttributes
@@ -51,7 +52,8 @@ class Config : PersistentStateComponent<Config.State> {
         var userId: Int? = null,
         var isFirstRun: Boolean = true,
         var allowGenerateGuidelines: Boolean = false,
-        var addAnalysisGuidelines: Boolean = false
+        var addAnalysisGuidelines: Boolean = false,
+        var selectedAiAgent: AiAgentName = AiAgentName.JUNIE
     )
 
     override fun getState(): State = state

--- a/src/main/kotlin/com/codacy/intellij/plugin/services/common/ConfigConfigurable.kt
+++ b/src/main/kotlin/com/codacy/intellij/plugin/services/common/ConfigConfigurable.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.options.SearchableConfigurable
 import org.jetbrains.annotations.NonNls
 import javax.swing.JComponent
+import com.codacy.intellij.plugin.services.agent.AiAgentName
 
 class ConfigConfigurable : SearchableConfigurable {
 
@@ -15,6 +16,7 @@ class ConfigConfigurable : SearchableConfigurable {
     override fun createComponent(): JComponent? {
         form = ConfigWindowForm()
         fetchAllAvailableCliVersions()
+        populateAiAgentsDropdown()
         // Initialize checkboxes with current state
         form?.setGenerateGuidelines(config.state.allowGenerateGuidelines)
         form?.setAnalyzeGeneratedCode(config.state.addAnalysisGuidelines)
@@ -37,17 +39,28 @@ class ConfigConfigurable : SearchableConfigurable {
         }
     }
 
+    private fun populateAiAgentsDropdown() {
+        val state = config.state
+        val agents = listOf(
+            AiAgentName.JUNIE,
+            AiAgentName.GITHUB_COPILOT
+        )
+        form?.setAvailableAiAgentsDropdown(agents, state.selectedAiAgent)
+    }
+
     override fun isModified(): Boolean {
         val state = Config.instance.state
         val versionChanged = form?.getSelectedAvailableCliVersion() != state.selectedCliVersion
+        val selectedAgentChanged = form?.getSelectedAiAgent() != state.selectedAiAgent
         val generateGuidelinesChanged = (form?.getGenerateGuidelines() ?: false) != state.allowGenerateGuidelines
         val analyzeGeneratedCodeChanged = (form?.getAnalyzeGeneratedCode() ?: false) != state.addAnalysisGuidelines
-        return versionChanged || generateGuidelinesChanged || analyzeGeneratedCodeChanged
+        return versionChanged || selectedAgentChanged || generateGuidelinesChanged || analyzeGeneratedCodeChanged
     }
 
     override fun apply() {
         val state = Config.instance.state
         state.selectedCliVersion = form?.getSelectedAvailableCliVersion() ?: ""
+        state.selectedAiAgent = form?.getSelectedAiAgent() ?: AiAgentName.JUNIE
         state.allowGenerateGuidelines = form?.getGenerateGuidelines() ?: false
         state.addAnalysisGuidelines = form?.getAnalyzeGeneratedCode() ?: false
         // Ensure settings are persisted immediately
@@ -57,6 +70,7 @@ class ConfigConfigurable : SearchableConfigurable {
     override fun reset() {
         val state = Config.instance.state
         form?.setAvailableCliVersionsDropdown(state.availableCliVersions, state.selectedCliVersion)
+        populateAiAgentsDropdown()
         form?.setGenerateGuidelines(state.allowGenerateGuidelines)
         form?.setAnalyzeGeneratedCode(state.addAnalysisGuidelines)
     }

--- a/src/main/kotlin/com/codacy/intellij/plugin/services/common/ConfigWindowForm.kt
+++ b/src/main/kotlin/com/codacy/intellij/plugin/services/common/ConfigWindowForm.kt
@@ -1,15 +1,16 @@
 package com.codacy.intellij.plugin.services.common
 
+import com.codacy.intellij.plugin.services.agent.AiAgentName
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.ui.dsl.builder.panel
-import javax.swing.JCheckBox
-import javax.swing.JComponent
-import javax.swing.JPanel
+import javax.swing.*
+import java.awt.Component
 
 class ConfigWindowForm {
 
     private val panel: JPanel = JPanel()
     private val availableCliVersionsDropdownMenu = ComboBox<String>()
+    private val availableAiAgentsDropdownMenu = ComboBox<AiAgentName>()
     private val generateGuidelinesCheckbox = JCheckBox("Generate Guidelines")
 
     //TODO: This checkbox might be a little ambiguous, it doesn't just let agent run codacy-cli,
@@ -20,10 +21,23 @@ class ConfigWindowForm {
     val component: JComponent get() = panel
 
     init {
+        availableAiAgentsDropdownMenu.renderer = object : DefaultListCellRenderer() {
+            override fun getListCellRendererComponent(
+                list: JList<*>, value: Any?, index: Int, isSelected: Boolean, cellHasFocus: Boolean
+            ): Component {
+                val comp = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus)
+                text = (value as? AiAgentName)?.toString() ?: ""
+                return comp
+            }
+        }
+
         panel.add(
             panel {
                 row("Codacy CLI Version:") {
                     cell(availableCliVersionsDropdownMenu)
+                }
+                row("AI Agent:") {
+                    cell(availableAiAgentsDropdownMenu)
                 }
                 row {
                     cell(generateGuidelinesCheckbox)
@@ -51,6 +65,24 @@ class ConfigWindowForm {
 
     fun getSelectedAvailableCliVersion(): String? {
         return availableCliVersionsDropdownMenu.selectedItem as? String
+    }
+
+    fun setAvailableAiAgentsDropdown(items: List<AiAgentName>, selected: AiAgentName?) {
+        availableAiAgentsDropdownMenu.removeAllItems()
+        items.forEach { availableAiAgentsDropdownMenu.addItem(it) }
+        selectAvailableAiAgent(selected)
+    }
+
+    fun selectAvailableAiAgent(item: AiAgentName?) {
+        if (item != null) {
+            availableAiAgentsDropdownMenu.selectedItem = item
+        } else {
+            availableAiAgentsDropdownMenu.selectedIndex = -1
+        }
+    }
+
+    fun getSelectedAiAgent(): AiAgentName? {
+        return availableAiAgentsDropdownMenu.selectedItem as? AiAgentName
     }
 
     fun setGenerateGuidelines(value: Boolean) {

--- a/src/main/kotlin/com/codacy/intellij/plugin/views/CodacyCliStatusBarWidget.kt
+++ b/src/main/kotlin/com/codacy/intellij/plugin/views/CodacyCliStatusBarWidget.kt
@@ -68,14 +68,15 @@ class CodacyCliStatusBarWidget(private val project: Project) :
     override fun getIcon(): Icon = cliService?.codacyCliState?.icon ?: CodacyCliState.NOT_INSTALLED.icon
 
     override fun getTooltipText(): String {
+        val selectedAiAgentName = "AI Agent: ${aiAgentService?.aiAgent?.aiAgentName.toString()}"
         return when (cliService?.codacyCliState) {
-            is CodacyCliState.INSTALLED -> "Codacy CLI is installed, waiting to be initialized"
-            is CodacyCliState.INSTALLING -> "Codacy CLI is being installed, please wait..."
-            is CodacyCliState.INITIALIZED -> "Codacy CLI is initialized and ready to use"
-            is CodacyCliState.ANALYZING -> "Codacy CLI is analyzing your code, please wait..."
-            is CodacyCliState.ERROR -> "An error occurred with Codacy CLI: ${cliService?.codacyCliState}"
-            is CodacyCliState.NOT_INSTALLED -> "Codacy CLI is not installed, please install it"
-            else -> "Something went wrong"
+            is CodacyCliState.INSTALLED -> "Codacy CLI is installed, waiting to be initialized - $selectedAiAgentName"
+            is CodacyCliState.INSTALLING -> "Codacy CLI is being installed, please wait... - $selectedAiAgentName"
+            is CodacyCliState.INITIALIZED -> "Codacy CLI is initialized and ready to use - $selectedAiAgentName"
+            is CodacyCliState.ANALYZING -> "Codacy CLI is analyzing your code, please wait... - $selectedAiAgentName"
+            is CodacyCliState.ERROR -> "An error occurred with Codacy CLI: ${cliService?.codacyCliState} - $selectedAiAgentName"
+            is CodacyCliState.NOT_INSTALLED -> "Codacy CLI is not installed, please install it - $selectedAiAgentName"
+            else -> "Something went wrong with the CLI - $selectedAiAgentName"
         }
     }
 


### PR DESCRIPTION
Additional config option to select an AI agent (defaults to Junie)
AI agent buttons for installing MCP and adding guidelines will not 
show up until user installs and enables the plugin. There will be a button
prompting user to install it which opens a plugin marketplace, but user still has
to manually choose the plugin, there does not seem an option to automate it further.