### PR TITLE
fix: Check if ide is IDEA, warn user if its not

### DIFF
--- a/src/main/kotlin/com/codacy/intellij/plugin/services/cli/CodacyCliService.kt
+++ b/src/main/kotlin/com/codacy/intellij/plugin/services/cli/CodacyCliService.kt
@@ -28,6 +28,7 @@ import com.codacy.intellij.plugin.telemetry.Telemetry
 import com.intellij.icons.AllIcons
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
+import com.intellij.openapi.application.ApplicationNamesInfo
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.updateSettings.impl.pluginsAdvertisement.notificationGroup
@@ -127,6 +128,8 @@ class CodacyCliService() {
             this.pathsBehaviour = pathsBehaviour
             this.rootPath = pathsBehaviour.rootPath(project)
 
+            detectIde()
+
             setServiceState(ServiceState.RUNNING)
 
             isServiceInstantiated = true
@@ -200,6 +203,11 @@ class CodacyCliService() {
                 }
 
                 else -> {
+                    notificationGroup.createNotification(
+                        "Unsupported OS",
+                        "The Codacy plugin does not support the operating system: $systemOs",
+                        NotificationType.ERROR
+                    ).notify(project)
                     throw IllegalStateException("Unsupported OS: $systemOs")
                 }
             }
@@ -642,6 +650,18 @@ class CodacyCliService() {
             function(tempFile, tempFilePath)
         } finally {
             tempFile.delete()
+        }
+    }
+
+    private fun detectIde() {
+        val ide = ApplicationNamesInfo.getInstance()
+
+        if (ide.productName.lowercase().contains("idea").not()) {
+            notificationGroup.createNotification(
+                "Non supported IDE Detected",
+                "Currently we do not actively test the Codacy plugin on ${ide.productName}. Please consider using it on IntelliJ IDEA for the best experience.",
+                NotificationType.INFORMATION
+            ).notify(project)
         }
     }
 }

--- a/src/main/kotlin/com/codacy/intellij/plugin/services/common/ConfigConfigurable.kt
+++ b/src/main/kotlin/com/codacy/intellij/plugin/services/common/ConfigConfigurable.kt
@@ -1,12 +1,12 @@
 package com.codacy.intellij.plugin.services.common
 
+import com.codacy.intellij.plugin.services.agent.AiAgentName
 import com.codacy.intellij.plugin.services.common.Config.Companion.CODACY_CLI_RELEASES_LINK
 import com.google.gson.JsonParser
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.options.SearchableConfigurable
 import org.jetbrains.annotations.NonNls
 import javax.swing.JComponent
-import com.codacy.intellij.plugin.services.agent.AiAgentName
 
 class ConfigConfigurable : SearchableConfigurable {
 
@@ -28,13 +28,9 @@ class ConfigConfigurable : SearchableConfigurable {
         ApplicationManager.getApplication().executeOnPooledThread {
             ApplicationManager.getApplication().invokeLater {
                 val state = config.state
-                if (state.availableCliVersions.isEmpty()) {
-                    val tagNames = fetchAvailableCliVersions()
-                    state.availableCliVersions = tagNames
-                    form?.setAvailableCliVersionsDropdown(tagNames, state.selectedCliVersion)
-                } else {
-                    form?.setAvailableCliVersionsDropdown(state.availableCliVersions, state.selectedCliVersion)
-                }
+                val tagNames = fetchAvailableCliVersions()
+                state.availableCliVersions = tagNames
+                form?.setAvailableCliVersionsDropdown(tagNames, state.selectedCliVersion)
             }
         }
     }


### PR DESCRIPTION
While we permit usage of the extension, we should warn users that we only actively support/test IDEA.

Small fix to update list of CLI versions even if list already exists.