### PR TITLE
feat: reviewing state change events

### DIFF
--- a/src/main/kotlin/com/codacy/intellij/plugin/services/cli/CodacyCliService.kt
+++ b/src/main/kotlin/com/codacy/intellij/plugin/services/cli/CodacyCliService.kt
@@ -19,6 +19,8 @@ import com.codacy.intellij.plugin.services.common.Config.Companion.CODACY_TOOLS_
 import com.codacy.intellij.plugin.services.common.Config.Companion.CODACY_YAML_NAME
 import com.codacy.intellij.plugin.services.common.GitRemoteParser
 import com.codacy.intellij.plugin.services.common.IconUtils
+import com.codacy.intellij.plugin.services.common.OsType
+import com.codacy.intellij.plugin.services.common.SystemDetectionService
 import com.codacy.intellij.plugin.services.git.GitProvider
 import com.codacy.intellij.plugin.services.paths.PathsBehaviour
 import com.codacy.intellij.plugin.services.paths.behaviour.PathsUnix
@@ -172,19 +174,19 @@ class CodacyCliService() {
             repository: String,
             project: Project,
         ): CodacyCliService {
-            val systemOs = System.getProperty("os.name").lowercase()
+            val systemOs = SystemDetectionService.detectOs()
             val cli = project.getService(CodacyCliService::class.java)
 
             val (cliBehaviour, pathsBehaviour) = when {
-                systemOs == "mac os x" || systemOs.contains("darwin") -> {
+                systemOs == OsType.MacOS -> {
                     CliUnix() to PathsUnix()
                 }
 
-                systemOs == "linux" -> {
+                systemOs == OsType.Linux -> {
                     CliUnix() to PathsUnix()
                 }
 
-                systemOs.contains("windows") -> {
+                systemOs == OsType.Windows -> {
                     val process = ProcessBuilder("wsl", "--list", "--quiet")
                         .redirectErrorStream(true)
                         .start()

--- a/src/main/kotlin/com/codacy/intellij/plugin/services/common/SystemDetectionService.kt
+++ b/src/main/kotlin/com/codacy/intellij/plugin/services/common/SystemDetectionService.kt
@@ -1,0 +1,103 @@
+package com.codacy.intellij.plugin.services.common
+
+import com.intellij.openapi.application.ApplicationNamesInfo
+
+enum class OsType {
+    Windows,
+    MacOS,
+    Linux,
+    Unknown;
+
+    override fun toString(): String {
+        return when (this) {
+            Windows -> "Windows"
+            MacOS -> "MacOS"
+            Linux -> "Linux"
+            Unknown -> "Unknown"
+        }
+    }
+
+
+    companion object {
+        fun fromString(osName: String): OsType {
+            return when (osName.lowercase()) {
+                "windows" -> Windows
+                "macos", "mac os", "mac" -> MacOS
+                "linux" -> Linux
+                else -> Unknown // Default to Unknown if OS is not recognized
+            }
+        }
+    }
+}
+
+
+enum class IdeType {
+    Intellij,
+    Webstorm,
+    Pycharm,
+    Phpstorm,
+    Rubymine,
+    Goland,
+    Rider,
+    Clion,
+    Datagrip,
+    Dataspell,
+    Unknown;
+
+    override fun toString(): String {
+        return when (this) {
+            Intellij -> "IntelliJ"
+            Webstorm -> "WebStorm"
+            Pycharm -> "PyCharm"
+            Phpstorm -> "PhpStorm"
+            Rubymine -> "RubyMine"
+            Goland -> "GoLand"
+            Rider -> "Rider"
+            Clion -> "CLion"
+            Datagrip -> "DataGrip"
+            Dataspell -> "DataSpell"
+            Unknown -> "Unknown"
+        }
+    }
+
+    companion object {
+
+        fun fromString(ideName: String): IdeType {
+            return when (ideName.lowercase()) {
+                "intellij" -> Intellij
+                "webstorm" -> Webstorm
+                "pycharm" -> Pycharm
+                "phpstorm" -> Phpstorm
+                "rubymine" -> Rubymine
+                "goland" -> Goland
+                "rider" -> Rider
+                "clion" -> Clion
+                "datagrip" -> Datagrip
+                "dataspell" -> Dataspell
+                else -> Unknown
+            }
+        }
+    }
+}
+
+
+object SystemDetectionService {
+
+
+    fun detectOs(): OsType {
+        val systemOs = System.getProperty("os.name").lowercase()
+        return when {
+            systemOs.contains("win") || systemOs.contains("windows") -> OsType.Windows
+            systemOs.contains("mac os x") || systemOs.contains("darwin") -> OsType.MacOS
+            listOf("nux", "nix", "aix", "linux").any { systemOs.contains(it) } -> OsType.Linux
+            else -> OsType.Unknown
+        }
+    }
+
+    fun detectIde(): IdeType = IdeType
+        .fromString(
+            ApplicationNamesInfo.getInstance().productName.lowercase()
+        )
+
+
+}

--- a/src/main/kotlin/com/codacy/intellij/plugin/services/git/RepositoryManager.kt
+++ b/src/main/kotlin/com/codacy/intellij/plugin/services/git/RepositoryManager.kt
@@ -109,7 +109,6 @@ class RepositoryManager(private val project: Project) {
             notifyDidUpdatePullRequest()
             setNewPullRequestState(PullRequestState.NoPullRequest)
             
-            // Set branch state based on current situation
             if (branch == null) {
                 setNewBranchState(BranchState.OnUnknownBranch)
             } else if (branch == repository?.defaultBranch?.name) {
@@ -123,7 +122,9 @@ class RepositoryManager(private val project: Project) {
             val currentHeadCommitSHA: String = GitProvider.getHeadCommitSHA(project)!!
             val currentHeadAhead: Boolean = GitProvider.isHeadAhead(project)
             if (pullRequest != null && prState === PullRequestState.Loaded && currentHeadCommitSHA != pullRequest?.meta?.headCommitSHA && !currentHeadAhead) {
-                if (refreshTimeout.isTimeoutRunning()) refreshTimeout.clearTimeout()
+                if (refreshTimeout.isTimeoutRunning()) {
+                    refreshTimeout.clearTimeout()
+                }
                 refreshTimeout.startTimeout(10000) {
                     Logger.info("Pushed all local commits, refreshing pull request...")
                     pullRequestInstance!!.refresh()
@@ -205,9 +206,7 @@ class RepositoryManager(private val project: Project) {
         val stateChange: Boolean = newState !== state
         state = newState
         if (stateChange) {
-            // Track repository state change telemetry
             Telemetry.track(RepositoryStateChangeEvent(newState.name))
-            
 //            TODO("execute command setContext")
             notifyDidChangeState()
         }

--- a/src/main/kotlin/com/codacy/intellij/plugin/services/paths/PathsBehaviour.kt
+++ b/src/main/kotlin/com/codacy/intellij/plugin/services/paths/PathsBehaviour.kt
@@ -1,5 +1,7 @@
 package com.codacy.intellij.plugin.services.paths
 
+import com.codacy.intellij.plugin.services.common.OsType
+import com.codacy.intellij.plugin.services.common.SystemDetectionService
 import com.codacy.intellij.plugin.services.paths.behaviour.PathsUnix
 import com.codacy.intellij.plugin.services.paths.behaviour.PathsWindows
 import com.intellij.openapi.project.Project
@@ -16,18 +18,13 @@ interface PathsBehaviour {
 
     object Factory {
         fun build(): PathsBehaviour {
-            val systemOs = System.getProperty("os.name").lowercase()
+            val osType = SystemDetectionService.detectOs()
 
             val pathsInstance = when {
-                systemOs == "mac os x" || systemOs.contains("darwin") -> PathsUnix()
-
-                systemOs == "linux" -> PathsUnix()
-
-                systemOs.contains("windows") -> PathsWindows()
-
-                else -> {
-                    throw IllegalStateException("Unsupported OS: $systemOs")
-                }
+                osType == OsType.MacOS -> PathsUnix()
+                osType == OsType.Linux -> PathsUnix()
+                osType == OsType.Windows -> PathsWindows()
+                else -> throw IllegalStateException("Unsupported OS: $osType")
             }
 
             return pathsInstance

--- a/src/main/kotlin/com/codacy/intellij/plugin/telemetry/Telemetry.kt
+++ b/src/main/kotlin/com/codacy/intellij/plugin/telemetry/Telemetry.kt
@@ -1,6 +1,7 @@
 package com.codacy.intellij.plugin.telemetry
 
 import com.codacy.intellij.plugin.services.common.Config
+import com.intellij.openapi.application.ApplicationNamesInfo
 import com.intellij.openapi.components.Service
 import com.segment.analytics.kotlin.core.Analytics
 
@@ -21,18 +22,15 @@ data object ExtensionUnloadedEvent : TelemetryEvent("extension_unloaded") {
 }
 
 data class RepositoryStateChangeEvent(val state: String) : TelemetryEvent("Repository State Change") {
-    override fun toPayload(): Map<String, Any?> =
-        mapOf("state" to state)
+    override fun toPayload(): Map<String, Any?> = mapOf("state" to state)
 }
 
 data class BranchStateChangeEvent(val state: String) : TelemetryEvent("Branch State Change") {
-    override fun toPayload(): Map<String, Any?> =
-        mapOf("state" to state)
+    override fun toPayload(): Map<String, Any?> = mapOf("state" to state)
 }
 
 data class PullRequestStateChangeEvent(val state: String) : TelemetryEvent("Pull Request State Change") {
-    override fun toPayload(): Map<String, Any?> =
-        mapOf("state" to state)
+    override fun toPayload(): Map<String, Any?> = mapOf("state" to state)
 }
 
 data class UnexpectedErrorEvent(val message: String) : TelemetryEvent("Unexpected Error") {
@@ -43,9 +41,38 @@ data class UnexpectedErrorEvent(val message: String) : TelemetryEvent("Unexpecte
 @Service
 object Telemetry {
 
-    private const val IDE: String = "jetbrains"
+    private fun normalizedIde(): String {
+        val product = ApplicationNamesInfo.getInstance().productName.lowercase()
+        val productKey = when {
+            product.contains("intellij") -> "intellij"
+            product.contains("webstorm") -> "webstorm"
+            product.contains("pycharm") -> "pycharm"
+            product.contains("phpstorm") -> "phpstorm"
+            product.contains("rubymine") -> "rubymine"
+            product.contains("goland") -> "goland"
+            product.contains("rider") -> "rider"
+            product.contains("clion") -> "clion"
+            product.contains("datagrip") -> "datagrip"
+            product.contains("dataspell") -> "dataspell"
+            else -> product.split(" ").firstOrNull() ?: "unknown"
+        }
+        return "jetbrains $productKey"
+    }
 
-    private val os: String = (System.getProperty("os.name") ?: "unknown").lowercase()
+    private fun normalizedOs(): String {
+        val raw = (System.getProperty("os.name") ?: "unknown").lowercase()
+        return when {
+            raw.contains("mac") || raw.contains("darwin") -> "darwin"
+            raw.contains("win") -> "win32"
+            raw.contains("nux") || raw.contains("nix") || raw.contains("aix") || raw.contains("linux") -> "linux"
+            else -> raw
+        }
+    }
+
+    private val ide: String by lazy { normalizedIde() }
+    private val os: String by lazy { normalizedOs() }
+
+    // Organization context intentionally omitted to keep PR concise
 
     private val analytics: Analytics by lazy {
         Analytics("ckhmOOSC1drlNKLYmzbK6BAJo8drHqNQ") {
@@ -64,7 +91,7 @@ object Telemetry {
             userId = userId.toString(),
             traits = mapOf(
                 "anonymousId" to anonymousId,
-                "ide" to IDE,
+                "ide" to ide,
                 "os" to os
             )
         )
@@ -80,7 +107,7 @@ object Telemetry {
             properties = mapOf(
                 "anonymousId" to anonymousId,
                 "userId" to userId,
-                "ide" to IDE,
+                "ide" to ide,
                 "os" to os
             ) + event.toPayload()
         )

--- a/src/main/kotlin/com/codacy/intellij/plugin/telemetry/Telemetry.kt
+++ b/src/main/kotlin/com/codacy/intellij/plugin/telemetry/Telemetry.kt
@@ -43,36 +43,41 @@ object Telemetry {
 
     private fun normalizedIde(): String {
         val product = ApplicationNamesInfo.getInstance().productName.lowercase()
-        val productKey = when {
-            product.contains("intellij") -> "intellij"
-            product.contains("webstorm") -> "webstorm"
-            product.contains("pycharm") -> "pycharm"
-            product.contains("phpstorm") -> "phpstorm"
-            product.contains("rubymine") -> "rubymine"
-            product.contains("goland") -> "goland"
-            product.contains("rider") -> "rider"
-            product.contains("clion") -> "clion"
-            product.contains("datagrip") -> "datagrip"
-            product.contains("dataspell") -> "dataspell"
-            else -> product.split(" ").firstOrNull() ?: "unknown"
-        }
+        val known = listOf(
+            "intellij",
+            "webstorm",
+            "pycharm",
+            "phpstorm",
+            "rubymine",
+            "goland",
+            "rider",
+            "clion",
+            "datagrip",
+            "dataspell"
+        )
+
+        val match = known.firstOrNull { product.contains(it) }
+        val productKey = match ?: product.split(" ").firstOrNull() ?: "unknown"
         return "jetbrains $productKey"
     }
 
     private fun normalizedOs(): String {
         val raw = (System.getProperty("os.name") ?: "unknown").lowercase()
+        val isMac = raw.contains("mac") || raw.contains("darwin")
+        val isWin = raw.contains("win")
+        val linuxTokens = listOf("nux", "nix", "aix", "linux")
+        val isLinux = linuxTokens.any { raw.contains(it) }
+
         return when {
-            raw.contains("mac") || raw.contains("darwin") -> "darwin"
-            raw.contains("win") -> "win32"
-            raw.contains("nux") || raw.contains("nix") || raw.contains("aix") || raw.contains("linux") -> "linux"
+            isMac -> "darwin"
+            isWin -> "win32"
+            isLinux -> "linux"
             else -> raw
         }
     }
 
     private val ide: String by lazy { normalizedIde() }
     private val os: String by lazy { normalizedOs() }
-
-    // Organization context intentionally omitted to keep PR concise
 
     private val analytics: Analytics by lazy {
         Analytics("ckhmOOSC1drlNKLYmzbK6BAJo8drHqNQ") {

--- a/src/main/kotlin/com/codacy/intellij/plugin/telemetry/Telemetry.kt
+++ b/src/main/kotlin/com/codacy/intellij/plugin/telemetry/Telemetry.kt
@@ -25,9 +25,7 @@ data class RepositoryStateChangeEvent(val state: String) : TelemetryEvent("Repos
     override fun toPayload(): Map<String, Any?> = mapOf("state" to state)
 }
 
-data class BranchStateChangeEvent(val state: String) : TelemetryEvent("Branch State Change") {
-    override fun toPayload(): Map<String, Any?> = mapOf("state" to state)
-}
+// Branch state change telemetry removed (no longer tracked)
 
 data class PullRequestStateChangeEvent(val state: String) : TelemetryEvent("Pull Request State Change") {
     override fun toPayload(): Map<String, Any?> = mapOf("state" to state)

--- a/src/main/kotlin/com/codacy/intellij/plugin/telemetry/Telemetry.kt
+++ b/src/main/kotlin/com/codacy/intellij/plugin/telemetry/Telemetry.kt
@@ -25,8 +25,6 @@ data class RepositoryStateChangeEvent(val state: String) : TelemetryEvent("Repos
     override fun toPayload(): Map<String, Any?> = mapOf("state" to state)
 }
 
-// Branch state change telemetry removed (no longer tracked)
-
 data class PullRequestStateChangeEvent(val state: String) : TelemetryEvent("Pull Request State Change") {
     override fun toPayload(): Map<String, Any?> = mapOf("state" to state)
 }

--- a/src/main/kotlin/com/codacy/intellij/plugin/telemetry/Telemetry.kt
+++ b/src/main/kotlin/com/codacy/intellij/plugin/telemetry/Telemetry.kt
@@ -25,6 +25,10 @@ data class RepositoryStateChangeEvent(val state: String) : TelemetryEvent("Repos
     override fun toPayload(): Map<String, Any?> = mapOf("state" to state)
 }
 
+data class BranchStateChangeEvent(val state: String) : TelemetryEvent("Branch State Change") {
+    override fun toPayload(): Map<String, Any?> = mapOf("state" to state)
+}
+
 data class PullRequestStateChangeEvent(val state: String) : TelemetryEvent("Pull Request State Change") {
     override fun toPayload(): Map<String, Any?> = mapOf("state" to state)
 }

--- a/src/main/kotlin/com/codacy/intellij/plugin/telemetry/Telemetry.kt
+++ b/src/main/kotlin/com/codacy/intellij/plugin/telemetry/Telemetry.kt
@@ -1,6 +1,7 @@
 package com.codacy.intellij.plugin.telemetry
 
 import com.codacy.intellij.plugin.services.common.Config
+import com.codacy.intellij.plugin.services.common.SystemDetectionService
 import com.intellij.openapi.application.ApplicationNamesInfo
 import com.intellij.openapi.components.Service
 import com.segment.analytics.kotlin.core.Analytics
@@ -41,43 +42,10 @@ data class UnexpectedErrorEvent(val message: String) : TelemetryEvent("Unexpecte
 @Service
 object Telemetry {
 
-    private fun normalizedIde(): String {
-        val product = ApplicationNamesInfo.getInstance().productName.lowercase()
-        val known = listOf(
-            "intellij",
-            "webstorm",
-            "pycharm",
-            "phpstorm",
-            "rubymine",
-            "goland",
-            "rider",
-            "clion",
-            "datagrip",
-            "dataspell"
-        )
-
-        val match = known.firstOrNull { product.contains(it) }
-        val productKey = match ?: product.split(" ").firstOrNull() ?: "unknown"
-        return "jetbrains $productKey"
+    private val ide: String by lazy {
+        "JetBrains ${SystemDetectionService.detectIde()}"
     }
-
-    private fun normalizedOs(): String {
-        val raw = (System.getProperty("os.name") ?: "unknown").lowercase()
-        val isMac = raw.contains("mac") || raw.contains("darwin")
-        val isWin = raw.contains("win")
-        val linuxTokens = listOf("nux", "nix", "aix", "linux")
-        val isLinux = linuxTokens.any { raw.contains(it) }
-
-        return when {
-            isMac -> "darwin"
-            isWin -> "win32"
-            isLinux -> "linux"
-            else -> raw
-        }
-    }
-
-    private val ide: String by lazy { normalizedIde() }
-    private val os: String by lazy { normalizedOs() }
+    private val os: String by lazy { SystemDetectionService.detectOs().toString() }
 
     private val analytics: Analytics by lazy {
         Analytics("ckhmOOSC1drlNKLYmzbK6BAJo8drHqNQ") {


### PR DESCRIPTION
> [!CAUTION]
>**This PR was entirely done using Cursor + Codex. Review with care. 🙈** 

---
## Problem
After analysis, it was discovered that state change telemetry events were not being properly emitted by the IntelliJ extension. The extension was missing critical telemetry tracking for repository, pull request, and branch state transitions, which are essential for analytics and monitoring user behavior across different IDE extensions.

## Solution
This PR implements comprehensive telemetry state change tracking to match the VS Code extension behavior and includes several improvements for better IDE and OS parameter normalization.

## Changes Made
**🔧 Telemetry State Change Events**
- Added Repository State Change tracking: Now emits events when repository state transitions (Initializing, NeedsAuthentication, NoGitRepository, Loaded, NoRepository)
- Added Pull Request State Change tracking: Tracks PR state transitions (NoPullRequest, Loaded)
- Modified state change detection: Events are only emitted when state actually changes, preventing duplicate telemetry
- Standardized OS & IDE conventions

## Missing components

- Tracking branch state change is missing. Requires understanding analysed branches. we dont pull that info yet. might as well open a new PT
- Missing OrgID for parity with VScode